### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: site
           path: _site
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4.1.0
         with:
           name: site
           
       - name: Copy site to host
-        uses: appleboy/scp-action@v0.1.4
+        uses: appleboy/scp-action@v0.1.6
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.0](https://github.com/actions/download-artifact/releases/tag/v4.1.0)** on 2023-12-18T22:24:23Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)** on 2023-12-14T16:38:02Z
* **[appleboy/scp-action](https://github.com/appleboy/scp-action)** published a new release **[v0.1.6](https://github.com/appleboy/scp-action/releases/tag/v0.1.6)** on 2023-12-26T06:47:01Z
