### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
           name: site
           
       - name: Copy site to host
-        uses: appleboy/scp-action@v0.1.6
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[appleboy/scp-action](https://github.com/appleboy/scp-action)** published a new release **[v0.1.7](https://github.com/appleboy/scp-action/releases/tag/v0.1.7)** on 2024-01-01T05:48:02Z
