### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: site
           path: _site
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v4.1.0
+        uses: actions/download-artifact@v4.1.4
         with:
           name: site
           
       - name: Copy site to host
-        uses: appleboy/scp-action@v0.1.6
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.4](https://github.com/actions/download-artifact/releases/tag/v4.1.4)** on 2024-03-01T18:28:41Z
* **[appleboy/scp-action](https://github.com/appleboy/scp-action)** published a new release **[v0.1.7](https://github.com/appleboy/scp-action/releases/tag/v0.1.7)** on 2024-01-01T05:48:02Z
