### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.3.5
         with:
           name: site
           path: _site


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.5](https://github.com/actions/upload-artifact/releases/tag/v4.3.5)** on 2024-08-02T14:02:19Z
