### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.0
 
       - name: Build
         uses: jerryjvl/jekyll-build-action@v1

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
