### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45.0.3
+      uses: tj-actions/changed-files@v45.0.4
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v45.0.4](https://github.com/tj-actions/changed-files/releases/tag/v45.0.4)** on 2024-11-08T04:34:20Z
