### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: site
           path: _site

--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45.0.5
+      uses: tj-actions/changed-files@v45.0.6
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v45.0.6](https://github.com/tj-actions/changed-files/releases/tag/v45.0.6)** on 2025-01-04T19:12:24Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.5.0](https://github.com/actions/upload-artifact/releases/tag/v4.5.0)** on 2024-12-17T22:02:43Z
