### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: site
           path: _site
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v4.1.8
+        uses: actions/download-artifact@v4.1.9
         with:
           name: site
           

--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45.0.5
+      uses: tj-actions/changed-files@v45.0.7
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v45.0.7](https://github.com/tj-actions/changed-files/releases/tag/v45.0.7)** on 2025-02-05T02:56:53Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.9](https://github.com/actions/download-artifact/releases/tag/v4.1.9)** on 2025-02-25T21:26:04Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
