### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -14,7 +14,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v46.0.2
+      uses: tj-actions/changed-files@v46.0.3
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v46.0.3](https://github.com/tj-actions/changed-files/releases/tag/v46.0.3)** on 2025-03-23T10:28:37Z
