### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v4.2.1
+        uses: actions/download-artifact@v4.3.0
         with:
           name: site
           


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.3.0](https://github.com/actions/download-artifact/releases/tag/v4.3.0)** on 2025-04-24T16:28:16Z
