### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.0
 
       - name: Build
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v5.0.0
         with:
           name: site
           path: _site
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v6.0.0
         with:
           name: site
           

--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -10,7 +10,7 @@ jobs:
   social_post:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@v6.0.0
 
     - name: Get changed files
       id: changed-files

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v5.0.0](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)** on 2025-10-24T18:19:29Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)** on 2025-11-20T16:24:08Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v6.0.0](https://github.com/actions/download-artifact/releases/tag/v6.0.0)** on 2025-10-24T18:19:24Z
