### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.2
 
       - name: Build
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: site
           path: _site
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v8.0.0
         with:
           name: site
           

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@v1.290.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -50,7 +50,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4.0.0
 
   # Deployment job
   deploy:
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v4.0.5

--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -10,11 +10,11 @@ jobs:
   social_post:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@v6.0.2
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v47.0.0
+      uses: tj-actions/changed-files@v47.0.5
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v4.0.5](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)** on 2024-03-18T15:43:13Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)** on 2025-08-14T19:21:06Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v8.0.0](https://github.com/actions/download-artifact/releases/tag/v8.0.0)** on 2026-02-26T18:21:25Z
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v47.0.5](https://github.com/tj-actions/changed-files/releases/tag/v47.0.5)** on 2026-03-03T03:52:53Z
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.290.0](https://github.com/ruby/setup-ruby/releases/tag/v1.290.0)** on 2026-03-06T13:30:59Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v7.0.0](https://github.com/actions/upload-artifact/releases/tag/v7.0.0)** on 2026-02-26T18:21:17Z
