### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.3
 
       - name: Build
         uses: jerryjvl/jekyll-build-action@v1
 
       - name: Upload build
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: site
           path: _site
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: site
           

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -32,17 +32,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases/tag/v1.207.0
-        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        uses: ruby/setup-ruby@v1.313.0
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -50,7 +50,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
 
   # Deployment job
   deploy:
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/poster.yml
+++ b/.github/workflows/poster.yml
@@ -10,11 +10,11 @@ jobs:
   social_post:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5.0.0
+    - uses: actions/checkout@v6.0.3
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v47.0.0
+      uses: tj-actions/changed-files@v47.0.6
       # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
       # with:
       #   since_last_remote_commit: true

--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5.0.0
+      - uses: actions/checkout@v6.0.3
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ruby/setup-ruby](https://github.com/ruby/setup-ruby)** published a new release **[v1.313.0](https://github.com/ruby/setup-ruby/releases/tag/v1.313.0)** on 2026-06-11T18:13:47Z
* **[actions/configure-pages](https://github.com/actions/configure-pages)** published a new release **[v6.0.0](https://github.com/actions/configure-pages/releases/tag/v6.0.0)** on 2026-03-25T17:00:49Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v8.0.1](https://github.com/actions/download-artifact/releases/tag/v8.0.1)** on 2026-03-11T15:44:25Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v7.0.1](https://github.com/actions/upload-artifact/releases/tag/v7.0.1)** on 2026-04-10T17:31:14Z
* **[actions/deploy-pages](https://github.com/actions/deploy-pages)** published a new release **[v5.0.0](https://github.com/actions/deploy-pages/releases/tag/v5.0.0)** on 2026-03-25T16:59:14Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.3](https://github.com/actions/checkout/releases/tag/v6.0.3)** on 2026-06-02T14:35:13Z
* **[tj-actions/changed-files](https://github.com/tj-actions/changed-files)** published a new release **[v47.0.6](https://github.com/tj-actions/changed-files/releases/tag/v47.0.6)** on 2026-04-18T11:20:20Z
* **[actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact)** published a new release **[v5.0.0](https://github.com/actions/upload-pages-artifact/releases/tag/v5.0.0)** on 2026-04-10T18:22:59Z
